### PR TITLE
24 show back link on detail pages

### DIFF
--- a/components/Frame/Frame.module.css
+++ b/components/Frame/Frame.module.css
@@ -56,6 +56,10 @@
   transition: var(--mark-transition);
 }
 
+.backLink {
+  font-size: var(--size-xxl);
+}
+
 .logomark {
   height: var(--logomark-size);
   transition: var(--mark-transition);

--- a/components/Frame/Header.js
+++ b/components/Frame/Header.js
@@ -44,7 +44,17 @@ export default function Header() {
     };
   }, []);
 
-  const onActivityDetailPage = pathname === '/activity/[slug]';
+  //TODO This is a simple way of allowing 'back' navigation on activity pages.
+  //     With activities and organizations, defining the meaning of 'back' is more complex.
+  //     Consider all possible navigation paths, e.g.:
+  //     - results > activity
+  //     - results > activity > org
+  //     - results > org
+  //     - activity > org
+  //     - org
+  //     - org > activity > org
+  
+  const onDetailPage = pathname === '/activity/[slug]' || pathname === '/organization/[slug]';
   const href = { pathname: '/', query: getQuery() };
 
   return (
@@ -54,7 +64,7 @@ export default function Header() {
           <div className={logo}>
             <Link href={href}>
               <a>
-                {onActivityDetailPage ? (
+                {onDetailPage ? (
                   <BackLink />
                 ) : (
                   <TypeMark className={typemark} title={t('mainPageLink')} />

--- a/components/Frame/Header.js
+++ b/components/Frame/Header.js
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 
+import { useRouter } from 'next/router';
+
 import { useEffort, useTranslation } from '../../hooks';
 
 import { Content } from '../Content';
@@ -15,9 +17,16 @@ import {
   headerLogos,
   logo,
   typemark,
+  backLink,
 } from './Frame.module.css';
 
+function BackLink () {
+  const { t } = useTranslation();
+  return <span className={backLink}>{t('mainBackLink')}</span>
+}
+
 export default function Header() {
+  const { pathname } = useRouter();
   const { getQuery } = useEffort();
   const { t } = useTranslation();
   const [headerClassName, setHeaderClassName] = useState(headerWrapper);
@@ -34,7 +43,10 @@ export default function Header() {
       window.removeEventListener('scroll', handleScroll);
     };
   }, []);
+
+  const onActivityDetailPage = pathname === '/activity/[slug]';
   const href = { pathname: '/', query: getQuery() };
+
   return (
     <header className={headerClassName}>
       <Content className={headerContent}>
@@ -42,7 +54,11 @@ export default function Header() {
           <div className={logo}>
             <Link href={href}>
               <a>
-                <TypeMark className={typemark} title={t('mainPageLink')} />
+                {onActivityDetailPage ? (
+                  <BackLink />
+                ) : (
+                  <TypeMark className={typemark} title={t('mainPageLink')} />
+                )}
               </a>
             </Link>
           </div>


### PR DESCRIPTION
Simple solution to show to the user that they can go back. Wouldn't cover navigation between activities and organizations.
I think this needs some brainjuice and refactoring down the line.
Possible & current solution: Use "To overview" instead of "Back" as copy for `mainBackLink`