### PR TITLE
24 make login modal closable

### DIFF
--- a/components/CookieConsent/CookieConsent.js
+++ b/components/CookieConsent/CookieConsent.js
@@ -5,12 +5,12 @@ import { Markdown } from '../Markdown';
 
 import { button } from './CookieConsent.module.css';
 
-function CookieConsentForm({ children, confirm }) {
+function CookieConsentForm({ children, onConfirm }) {
   const { t } = useTranslation();
   return (
     <>
       {children}
-      <a className={button} onClick={confirm}>
+      <a className={button} onClick={onConfirm}>
         {t('cookieConsentButton')}
       </a>
     </>

--- a/components/CookieConsent/CookieConsent.js
+++ b/components/CookieConsent/CookieConsent.js
@@ -5,23 +5,23 @@ import { Markdown } from '../Markdown';
 
 import { button } from './CookieConsent.module.css';
 
-function CookieConsentForm({ children, close }) {
+function CookieConsentForm({ children, confirm }) {
   const { t } = useTranslation();
   return (
     <>
       {children}
-      <a className={button} onClick={close}>
+      <a className={button} onClick={confirm}>
         {t('cookieConsentButton')}
       </a>
     </>
   );
 }
 
-export default function CookieConsent({ onClose }) {
+export default function CookieConsent({ onConfirm }) {
   const { t } = useTranslation();
   return (
-    <Modal onClose={onClose}>
-      <CookieConsentForm>
+    <Modal canceable={false}>
+      <CookieConsentForm onConfirm={onConfirm}>
         <Markdown contents={t('cookieConsentText')} />
       </CookieConsentForm>
     </Modal>

--- a/components/Modal/Modal.js
+++ b/components/Modal/Modal.js
@@ -19,7 +19,15 @@ function ModalPortal({ children }) {
   return createPortal(children, el);
 }
 
-function ModalWrapper({ children, closing, onClose, className, ...props }) {
+function ModalWrapper({
+  children,
+  closing,
+  onClose,
+  canceable,
+  cancel,
+  className,
+  ...props
+}) {
   const [hidden, setHidden] = useState(true);
   useEffect(() => {
     setTimeout(() => setHidden(false));
@@ -30,8 +38,18 @@ function ModalWrapper({ children, closing, onClose, className, ...props }) {
       setTimeout(() => onClose(), 125);
     }
   }, [closing]);
+
+  const handlers = canceable ? {
+    onClick: e => {    
+      if(e.target === e.currentTarget) {
+        // Click on the modal wrapper happened outside the modal
+        console.log('cloio');
+        cancel();
+      }
+    }
+  } : {};
   return (
-    <div className={hidden ? hiddenWrapper : wrapper}>
+    <div className={hidden ? hiddenWrapper : wrapper} {...handlers}>
       <div {...props} className={concatClassnames(modal, className)}>
         {children}
       </div>
@@ -39,7 +57,13 @@ function ModalWrapper({ children, closing, onClose, className, ...props }) {
   );
 }
 
-export default function Modal({ children, onClose = () => {}, ...props }) {
+export default function Modal({
+  children,
+  canceable = true,
+  onClose = () => {},
+  onCancel = () => {},
+  ...props
+}) {
   const [open, setOpen] = useState(null);
   const [closing, setClosing] = useState(false);
   useEffect(() => {
@@ -48,7 +72,16 @@ export default function Modal({ children, onClose = () => {}, ...props }) {
   }, [open]);
   return open ? (
     <ModalPortal>
-      <ModalWrapper {...props} closing={closing} onClose={() => setOpen(false)}>
+      <ModalWrapper
+        {...props}
+        closing={closing}
+        canceable={canceable}
+        onClose={() => setOpen(false)}
+        cancel={() => {
+          setClosing(true);
+          onCancel();
+        }}
+      >
         {cloneElement(Children.only(children), {
           close() {
             setClosing(true);

--- a/components/Modal/Modal.js
+++ b/components/Modal/Modal.js
@@ -40,13 +40,12 @@ function ModalWrapper({
   }, [closing]);
 
   const handlers = canceable ? {
-    onClick: e => {    
+    onClick(e) {    
       if(e.target === e.currentTarget) {
         // Click on the modal wrapper happened outside the modal
-        console.log('cloio');
         cancel();
       }
-    }
+    },
   } : {};
   return (
     <div className={hidden ? hiddenWrapper : wrapper} {...handlers}>

--- a/hooks/useTracking.js
+++ b/hooks/useTracking.js
@@ -145,7 +145,7 @@ export function withTracking(Component, ConsentComponent) {
     return createElement(
       Fragment,
       {},
-      createElement(ConsentComponent, { onClose: () => setHasConsented(true) }),
+      createElement(ConsentComponent, { onConfirm: () => setHasConsented(true) }),
       createElement(Component, props)
     );
   };


### PR DESCRIPTION
- Adds `canceable` and `onCancel` props to modals
- Cookie consent doesn't rely on `Modal`'s `onClose` anymore but uses its own confirm logic.

Doesn't listen to Escape-key: After some playing around I felt the added complexity of listening to global events didn't seem to justify the added comfort for non-mobile users that know and want to use their escape key and don't have a touchbar ;)